### PR TITLE
emc branding, version increment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 PROGRAM=           MenuMeters
-VERSION=           1.9.7+emc
+VERSION=           1.9.8+emc
 DISTDIR=           ./dist
 DEPSDIR=           ./deps
 BINARIES=          /tmp/MenuMeters.dst

--- a/PrefPane/InfoPlistPreprocessor.h
+++ b/PrefPane/InfoPlistPreprocessor.h
@@ -9,7 +9,7 @@
 #ifndef InfoPlistPreprocessor_h
 #define InfoPlistPreprocessor_h
 
-#define MM_VERSION 1.9.7+emc
+#define MM_VERSION 1.9.8+emc
 #define MM_COPYRIGHT MenuMeters v. MM_VERSION, by many contributors
 
 #endif /* InfoPlistPreprocessor_h */

--- a/distribution.dist
+++ b/distribution.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="2">
-    <pkg-ref id="com.yujitach.MenuMeters"/>
+    <pkg-ref id="com.emcrisostomo.MenuMeters"/>
     <options customize="never" require-scripts="false"/>
     <volume-check>
         <allowed-os-versions>
@@ -9,12 +9,12 @@
     </volume-check>
     <choices-outline>
         <line choice="default">
-            <line choice="com.yujitach.MenuMeters"/>
+            <line choice="com.emcrisostomo.MenuMeters"/>
         </line>
     </choices-outline>
     <choice id="default"/>
-    <choice id="com.yujitach.MenuMeters" visible="false">
-        <pkg-ref id="com.yujitach.MenuMeters"/>
+    <choice id="com.emcrisostomo.MenuMeters" visible="false">
+        <pkg-ref id="com.emcrisostomo.MenuMeters"/>
     </choice>
-    <pkg-ref id="com.yujitach.MenuMeters" version="1.9.4" onConclusion="none">MenuMetersComponent.pkg</pkg-ref>
+    <pkg-ref id="com.emcrisostomo.MenuMeters" version="1.9.8" onConclusion="none">MenuMetersComponent.pkg</pkg-ref>
 </installer-gui-script>


### PR DESCRIPTION
Submitting this commit to more clearly change this fork's information from the old **com.yujitach** package ID to **com.emcrisostomo.** Also incremented one minor version to reflect this change happening. Tested on macOS Mojava using both the .pkg installer generated by Make, and the resultant .dmg as well.